### PR TITLE
Server poller now properly decodes command parameters

### DIFF
--- a/app/src/main/java/tickets/client/ServerPoller.java
+++ b/app/src/main/java/tickets/client/ServerPoller.java
@@ -55,7 +55,7 @@ public class ServerPoller implements IObserver {
     	        if (updates.getCommands() == null)
                     return;
                 for (Command c : updates.getCommands()) {
-                    System.out.println(c.getMethodName());
+                    c.decode();
                     c.execute(ModelFacade.getInstance());
                 }
                 lastCommand = updates.getLastCommandID();

--- a/app/src/main/java/tickets/client/async/CreateLobbyAsync.java
+++ b/app/src/main/java/tickets/client/async/CreateLobbyAsync.java
@@ -1,8 +1,6 @@
 
 package tickets.client.async;
 
-// import android.os.AsyncTask;
-
 import android.os.AsyncTask;
 
 import tickets.common.UserData;
@@ -50,6 +48,7 @@ class CreateLobbyAsync extends AsyncTask<Object, Void, JoinLobbyResponse> {
 			stateVal = ClientStateChange.ClientState.lobby;
 			ClientStateChange state = new ClientStateChange(stateVal);
 			modelRoot.setCurrentLobby(response.getLobby());
+            modelRoot.setPlayer(response.getPlayer());
 			modelRoot.updateObservable(state);
 		}
 		else {

--- a/app/src/main/java/tickets/common/Command.java
+++ b/app/src/main/java/tickets/common/Command.java
@@ -28,9 +28,13 @@ public class Command implements ICommand {
 		methodName = temp.getMethodName();
 		parameterTypeNames = temp.getParameterTypeNames();
 		parametersAsJsonStrings = temp.getParametersAsJsonStrings();
-		createParameterTypes();
-		createParametersFromJsonStrings();
+        decode();
 	}
+
+	public void decode() {
+        createParameterTypes();
+        createParametersFromJsonStrings();
+    }
 
 	public String getMethodName() {
 		return methodName;


### PR DESCRIPTION
ServerPoller was recieving commands but they were not properly being invoked on the ModelFacade because the parameters were not being decoded. This functionality has now been added.