### PR TITLE
Fixed some faulty server logic

### DIFF
--- a/app/src/main/java/tickets/server/ServerFacade.java
+++ b/app/src/main/java/tickets/server/ServerFacade.java
@@ -380,12 +380,16 @@ public class ServerFacade implements IServer {
         Map<Command, String> commandIDs = client.getCommandIDs();
 
         // Remove commands until the last received command
+        Command command = commands.peek();
+        String ID = commandIDs.get(command);
         while ((lastReceivedCommandID != null) &&
-                (commands.peek() != null)) {
-            Command command = commands.remove();
-            String ID = commandIDs.get(command);
+                (command != null) &&
+                Double.parseDouble(ID) <= Double.parseDouble(lastReceivedCommandID)) {
+            commands.remove();
             commandIDs.remove(command);
-            if (ID.equals(lastReceivedCommandID)) break;
+
+            command = commands.peek();
+            ID = commandIDs.get(command);
         }
 
         // Update the client proxy


### PR DESCRIPTION
The server used to chop off all waiting commands until it saw the last received command. It was chopping off commands past the last received command, thus not sending anything back to clients (including startGame). It's fixed now, and takes advantage of the fact that Command IDs go in ascending order according to when they were created on that particular client.