### PR TITLE
Bugfixes

### DIFF
--- a/app/src/main/java/tickets/server/model/game/ServerGame.java
+++ b/app/src/main/java/tickets/server/model/game/ServerGame.java
@@ -178,6 +178,12 @@ public class ServerGame extends Game {
         ServerPlayer player = getServerPlayer(authToken);
         if (player == null) throw new Exception("You are not a member of this game!");
 
+        // Players cannot claim both routes of a double route if there are fewer than 4 players.
+        if (players.size() < 4) {
+            if (route.isDouble() && (route.getFirstOwner() != null || route.getSecondOwner() != null))
+                throw new Exception("You may not claim this double route (fewer than 4 players)");
+        }
+
         String msg = player.claimRoute(route, cards);
         if (msg != null && !msg.equals(ServerPlayer.LAST_ROUND)) throw new Exception(msg);
 

--- a/app/src/main/java/tickets/server/model/game/ServerGame.java
+++ b/app/src/main/java/tickets/server/model/game/ServerGame.java
@@ -128,6 +128,10 @@ public class ServerGame extends Game {
         return null;
     }
 
+    public ServerPlayer getCurrentPlayer() {
+	    return players.get(currentPlayerIndex);
+    }
+
     public PlayerColor getPlayerColor(String authToken) {
 	    for (ServerPlayer player : players) {
 	        if (player.getAssociatedAuthToken().equals(authToken)) {
@@ -231,14 +235,13 @@ public class ServerGame extends Game {
         if (playersReady == players.size()) {
             players.get(currentPlayerIndex).startTurn();
         }
-        else startNextTurn();
+        else if (playersReady > players.size()) startNextTurn();
         return player.getDestinationCardOptions();
     }
 
     //----------------------------------------------------------------------------------------------
     // *** PRIVATE HELPER METHODS
     private void startNextTurn() {
-	    ServerFacade.getInstance().endTurn(this, players.get(currentPlayerIndex).getName());
 	    if (players.get(currentPlayerIndex).isLastPlayer()) {
 	        ServerFacade.getInstance().endGame(this);
 	        return;

--- a/app/src/main/java/tickets/server/model/game/ServerGame.java
+++ b/app/src/main/java/tickets/server/model/game/ServerGame.java
@@ -182,14 +182,14 @@ public class ServerGame extends Game {
         ServerPlayer player = getServerPlayer(authToken);
         if (player == null) throw new Exception("You are not a member of this game!");
 
-        String msg = player.claimRoute(route, cards);
-        if (msg != null && !msg.equals(ServerPlayer.LAST_ROUND)) throw new Exception(msg);
-
         // Players cannot claim both routes of a double route if there are fewer than 4 players.
         if (players.size() < 4) {
             if (route.isDouble() && (route.getFirstOwner() != null || route.getSecondOwner() != null))
-                throw new Exception("You may not claim this double route (fewer than 4 players)");
+                throw new Exception("This double route is unavailable (fewer than 4 players)");
         }
+
+        String msg = player.claimRoute(route, cards);
+        if (msg != null && !msg.equals(ServerPlayer.LAST_ROUND)) throw new Exception(msg);
 
         // Success! Now update the server model
         else {

--- a/app/src/main/java/tickets/server/model/game/ServerGame.java
+++ b/app/src/main/java/tickets/server/model/game/ServerGame.java
@@ -182,14 +182,14 @@ public class ServerGame extends Game {
         ServerPlayer player = getServerPlayer(authToken);
         if (player == null) throw new Exception("You are not a member of this game!");
 
+        String msg = player.claimRoute(route, cards);
+        if (msg != null && !msg.equals(ServerPlayer.LAST_ROUND)) throw new Exception(msg);
+
         // Players cannot claim both routes of a double route if there are fewer than 4 players.
         if (players.size() < 4) {
             if (route.isDouble() && (route.getFirstOwner() != null || route.getSecondOwner() != null))
                 throw new Exception("You may not claim this double route (fewer than 4 players)");
         }
-
-        String msg = player.claimRoute(route, cards);
-        if (msg != null && !msg.equals(ServerPlayer.LAST_ROUND)) throw new Exception(msg);
 
         // Success! Now update the server model
         else {


### PR DESCRIPTION
- Cannot claim both double routes if there are fewer than 4 players in the game.
- Game history messages were in the wrong order before ("ended turn" message would show up before the action that ended the turn). They are fixed now.

For some reason, clicking on the map causes my emulator to freeze and my computer to crash (this has happened 5 or 6 times in a row), so I haven't tested the first point, but the logic is easy and it should work. I have tested the second point.